### PR TITLE
refactor(typesense): drop overbroad depends_on on the app dashboard

### DIFF
--- a/typesense_dashboard.tf
+++ b/typesense_dashboard.tf
@@ -370,6 +370,4 @@ resource "google_monitoring_dashboard" "typesense_app" {
       tiles   = local.typesense_dashboard_tiles[each.key]
     }
   })
-
-  depends_on = [google_logging_metric.typesense_error_logs]
 }


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Follow-up to #37, addressing the AI reviewer's findings.

The `google_monitoring_dashboard.typesense_app` resource carried a resource-level `depends_on` on `google_logging_metric.typesense_error_logs`. With both resources using `for_each`, every dashboard instance waited on every metric instance, including apps without `log_check`, which serialized unrelated applies.

The dependency is not needed at all: the dashboard references the metric by its literal name, and the Cloud Monitoring API accepts dashboards whose metrics do not exist yet (confirmed by the `gcloud monitoring dashboards create --validate-only` check recorded in the archived OpenSpec change). Metric and dashboard still land in the same apply.

No plan diff for consumers: `depends_on` is ordering-only and not part of resource state.

The reviewer's second finding (restart chart missing a `container_name` filter) is intentionally not changed; see the reply on #37 for the rationale.


___

### **PR Type**
Enhancement


___

### **Description**
- Remove overbroad `depends_on` from `typesense_app` dashboard resource

- Prevents unrelated dashboard applies from serializing on all metric instances

- Dependency was unnecessary since Cloud Monitoring API accepts dashboards referencing not-yet-existing metrics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["google_monitoring_dashboard.typesense_app"] -- "removed depends_on" --> B["google_logging_metric.typesense_error_logs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>typesense_dashboard.tf</strong><dd><code>Remove unnecessary depends_on from dashboard resource</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

typesense_dashboard.tf

<ul><li>Removed resource-level <code>depends_on</code> on <br><code>google_logging_metric.typesense_error_logs</code> from <br><code>google_monitoring_dashboard.typesense_app</code><br> <li> Eliminates unnecessary serialization between dashboard and metric <br><code>for_each</code> instances<br> <li> Dashboard still references metric by literal name; API allows <br>non-existent metrics at creation</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/38/files#diff-e3dcd4fd0598b0fabf65aec0104bf4e738dc8eed934f61e5ce7212f0e01656a5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

