### PR TITLE
fix(typesense): use k8s_container resource type in flood alert filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-07-17
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.19.0...0.19.1)
+
 ### Fixed
 
 - Typesense flood alert policy creation rejected by the Cloud Monitoring API with `Error 400: The supplied filter does not specify a valid combination of metric and monitored resource descriptors`; the condition filter now targets `resource.type="k8s_container"` (the monitored resource of the backing log-based metric) instead of `global`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Typesense flood alert policy creation rejected by the Cloud Monitoring API with `Error 400: The supplied filter does not specify a valid combination of metric and monitored resource descriptors`; the condition filter now targets `resource.type="k8s_container"` (the monitored resource of the backing log-based metric) instead of `global`.
+
 ## [0.19.0] - 2026-07-17
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.18.0...0.19.0)

--- a/typesense.tf
+++ b/typesense.tf
@@ -371,7 +371,9 @@ resource "google_monitoring_alert_policy" "typesense_flood_alert" {
     display_name = "Typesense log rate > ${each.value.threshold_entries_per_minute} entries/min"
 
     condition_threshold {
-      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.typesense_log_flood[each.key].name}\" AND resource.type=\"global\""
+      # The backing log-based metric counts k8s_container log entries, so its
+      # time series carry the k8s_container monitored resource, never global.
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.typesense_log_flood[each.key].name}\" AND resource.type=\"k8s_container\""
       comparison      = "COMPARISON_GT"
       threshold_value = each.value.threshold_entries_per_minute
       duration        = "${each.value.duration_seconds}s"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

Applying 0.19.0 fails on both `typesense_flood_alert` policies with:

```
Error 400: The supplied filter does not specify a valid combination of metric and monitored resource descriptors. The query will not return any time series.
```

The condition filter targets `resource.type="global"`, but the backing log-based metric `typesense_log_volume_<app>` counts `k8s_container` log entries, so its time series only ever carry the `k8s_container` monitored resource. The Cloud Monitoring API validates the metric/resource pair at policy creation and rejects the policy.

The fix aligns the alert filter with the resource type the dashboard's log-volume widget already uses (`typesense_dashboard.tf`).

## Verification

Observed on a consumer project (GitLab `caleffi-gke`, apply job of the 0.19.0 bump): dashboards and log-based metrics created fine, both flood alert policies rejected with the error above. The 0.18.0 flood alert never got this far because policy creation failed earlier on the notification rate limit (fixed in 0.19.0), so this is the second latent bug in the same resource.

Refs: platform/#4649


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix `typesense_flood_alert` policy filter to use `resource.type="k8s_container"` instead of `global`

- Resolves `Error 400` rejection from Cloud Monitoring API on policy creation

- Aligns condition filter with monitored resource of backing log-based metric

- Add changelog entry for release 0.19.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["typesense_flood_alert condition filter"] -- "resource.type" --> B["global (invalid)"]
  A -- "fixed to" --> C["k8s_container (valid)"]
  D["log-based metric"] -- "emits" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>typesense.tf</strong><dd><code>Fix flood alert filter resource type mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

typesense.tf

<ul><li>Update <code>google_monitoring_alert_policy.typesense_flood_alert</code> condition <br>filter<br> <li> Change <code>resource.type</code> from <code>"global"</code> to <code>"k8s_container"</code><br> <li> Add explanatory comment about why <code>k8s_container</code> is the correct <br>resource type</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/40/files#diff-e3ee5f83608fe883e2e2c9f15fafa4868c2d6cc1d9bf3fcda6aa82cfa1e3e546">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 0.19.1 bug fix release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add entry for version 0.19.1 release<br> <li> Document the fix for the flood alert filter Error 400 issue</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/40/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

