### PR TITLE
feat(typesense): expose notification_prompts on log_check and flood_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `notification_prompts` (optional, `null` keeps the API default of notifying on incident open only) on the Typesense `log_check` and `flood_check` blocks, wired to `alert_strategy.notification_prompts` of the log-match and flood alert policies; set `["OPENED", "CLOSED"]` to also receive a notification when the incident auto-closes.
+
 ## [0.19.1] - 2026-07-17
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.19.0...0.19.1)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -87,6 +87,8 @@ module "example" {
           min_severity                             = "ERROR"
           logmatch_notification_rate_limit_seconds = 300
           auto_close_seconds                       = 3600
+          # Also notify when the incident auto-closes, as evidence of recovery.
+          notification_prompts = ["OPENED", "CLOSED"]
         }
         flood_check = {
           enabled                      = true

--- a/typesense.tf
+++ b/typesense.tf
@@ -323,7 +323,8 @@ resource "google_monitoring_alert_policy" "typesense_logmatch_alert" {
   notification_channels = local.typesense_check_notification_channels[each.key].log_check
 
   alert_strategy {
-    auto_close = "${each.value.auto_close_seconds}s"
+    auto_close           = "${each.value.auto_close_seconds}s"
+    notification_prompts = each.value.notification_prompts
     notification_rate_limit {
       period = "${each.value.logmatch_notification_rate_limit_seconds}s"
     }
@@ -403,7 +404,8 @@ resource "google_monitoring_alert_policy" "typesense_flood_alert" {
   # notification_rate_limit is only accepted by the API on condition_matched_log
   # policies; this policy uses condition_threshold, so none is set here.
   alert_strategy {
-    auto_close = "${each.value.auto_close_seconds}s"
+    auto_close           = "${each.value.auto_close_seconds}s"
+    notification_prompts = each.value.notification_prompts
   }
 
   depends_on = [google_logging_metric.typesense_log_flood]

--- a/variables.tf
+++ b/variables.tf
@@ -253,6 +253,7 @@ variable "typesense" {
         auto_close_seconds                       = optional(number, 3600)
         notification_enabled                     = optional(bool, null)
         notification_channels                    = optional(list(string), null)
+        notification_prompts                     = optional(list(string), null)
       }), null)
 
       flood_check = optional(object({
@@ -263,6 +264,7 @@ variable "typesense" {
         auto_close_seconds           = optional(number, 86400)
         notification_enabled         = optional(bool, null)
         notification_channels        = optional(list(string), null)
+        notification_prompts         = optional(list(string), null)
       }), null)
 
       # Workload vitals: saturation and availability alerts built on free GKE


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @andypanix._

## Summary

The Typesense log-match and flood alert policies only ever notify on incident open. Their incidents auto-close after `auto_close_seconds`, but no closure notification is sent, so notification channels such as Slack show a trail of "Alert open" messages with no evidence that the problem was resolved.

This PR exposes the `alert_strategy.notification_prompts` field, already supported by `container_check.pod_restart` and `workload_check`, on the `log_check` and `flood_check` blocks:

- `variables.tf`: adds `notification_prompts = optional(list(string), null)` to both blocks.
- `typesense.tf`: wires the value into `alert_strategy.notification_prompts` of `typesense_logmatch_alert` and `typesense_flood_alert`.
- `examples/main.tf`: shows the `["OPENED", "CLOSED"]` usage on `log_check`.
- `CHANGELOG.md`: entry under Unreleased.

The default `null` preserves the current behavior, so the change is fully backwards compatible. Consumers set `["OPENED", "CLOSED"]` to receive a closure notification when the incident auto-closes.

## Testing

Verified against a real consumer (caleffi-gke, project `caleffi-production-cluster`): pointing the module ref at this branch and setting `notification_prompts = ["OPENED", "CLOSED"]` on both checks of both Typesense apps produces a clean `terraform plan` with 4 in-place updates, each adding only:

```
~ alert_strategy {
    ~ notification_prompts = [
        + "OPENED",
        + "CLOSED",
      ]
  }
```

`terraform validate`, `fmt` and `tflint` pass on the consumer side.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add `notification_prompts` variable to `log_check` and `flood_check` blocks

- Wire `notification_prompts` into `alert_strategy` of Typesense logmatch and flood alert policies

- Update example to demonstrate `["OPENED", "CLOSED"]` usage

- Document change in CHANGELOG under Unreleased


___

### Diagram Walkthrough


```mermaid
flowchart LR
  var["variables.tf: add notification_prompts option"] -- "wired into" --> alert["typesense.tf: alert_strategy.notification_prompts"]
  alert -- "used by" --> logmatch["typesense_logmatch_alert"]
  alert -- "used by" --> flood["typesense_flood_alert"]
  example["examples/main.tf: usage example"] -- "demonstrates" --> var
  changelog["CHANGELOG.md: Unreleased entry"] -- "documents" --> var
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add notification_prompts option to log_check and flood_check</code></dd></summary>
<hr>

variables.tf

<ul><li>Add <code>notification_prompts = optional(list(string), null)</code> to <code>log_check</code> <br>block<br> <li> Add same optional field to <code>flood_check</code> block</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/41/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>typesense.tf</strong><dd><code>Wire notification_prompts into Typesense alert policies</code>&nbsp; &nbsp; </dd></summary>
<hr>

typesense.tf

<ul><li>Set <code>notification_prompts</code> in <code>alert_strategy</code> block of <br><code>typesense_logmatch_alert</code><br> <li> Set <code>notification_prompts</code> in <code>alert_strategy</code> block of <br><code>typesense_flood_alert</code><br> <li> Reformat <code>auto_close</code> assignment alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/41/files#diff-e3ee5f83608fe883e2e2c9f15fafa4868c2d6cc1d9bf3fcda6aa82cfa1e3e546">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Demonstrate notification_prompts usage in example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/main.tf

<ul><li>Add example usage of <code>notification_prompts = ["OPENED", "CLOSED"]</code> on <br><code>log_check</code><br> <li> Add comment explaining closure notification behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/41/files#diff-96d2eb4482c8b32134388cfb862977ed0087f5a8acc4d73a8ad8d30985469f77">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document notification_prompts addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add Unreleased entry describing new `notification_prompts` field


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/41/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

