### PR TITLE
docs(changelog): release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-23
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.19.1...0.20.0)
+
 ### Added
 
 - `notification_prompts` (optional, `null` keeps the API default of notifying on incident open only) on the Typesense `log_check` and `flood_check` blocks, wired to `alert_strategy.notification_prompts` of the log-match and flood alert policies; set `["OPENED", "CLOSED"]` to also receive a notification when the incident auto-closes.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @andypanix._

Cuts the CHANGELOG for release 0.20.0, containing the Typesense `notification_prompts` addition on `log_check` and `flood_check` (#41).


___

### **PR Type**
Documentation


___

### **Description**
- Cut CHANGELOG entry for release `0.20.0`

- Adds comparison link to previous version `0.19.1`

- Documents `notification_prompts` addition under new version section


___

### Diagram Walkthrough


```mermaid
flowchart LR
  unreleased["Unreleased section"] -- "moved to" --> release["0.20.0 - 2026-07-23"]
  release -- "includes" --> notif["notification_prompts feature entry"]
  release -- "links to" --> compare["Compare link 0.19.1...0.20.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Release CHANGELOG entry for 0.20.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds new <code>[0.20.0] - 2026-07-23</code> version section<br> <li> Adds compare link between <code>0.19.1</code> and <code>0.20.0</code><br> <li> Moves <code>notification_prompts</code> entry under the new release section</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/42/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

