### PR TITLE
fix(typesense): validate log_check notification_prompts at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-07-23
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.20.0...0.20.1)
+
+### Fixed
+
+- Plan-time validation rejecting `log_check.notification_prompts` values other than `["OPENED"]`: the Cloud Monitoring API refuses other prompts on log-match alert policies (`Error 400: log-based alert policies notification prompts must be [OPENED]`), so the 0.20.0 example of setting `["OPENED", "CLOSED"]` on `log_check` failed at apply time. The example now shows `["OPENED"]` on `log_check`; `["OPENED", "CLOSED"]` remains valid on `flood_check`, whose threshold-based policies the API accepts it for.
+
 ## [0.20.0] - 2026-07-23
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-services-monitoring/compare/0.19.1...0.20.0)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -87,8 +87,9 @@ module "example" {
           min_severity                             = "ERROR"
           logmatch_notification_rate_limit_seconds = 300
           auto_close_seconds                       = 3600
-          # Also notify when the incident auto-closes, as evidence of recovery.
-          notification_prompts = ["OPENED", "CLOSED"]
+          # The Cloud Monitoring API only accepts ["OPENED"] on log-match
+          # policies; closure notifications are not available for them.
+          notification_prompts = ["OPENED"]
         }
         flood_check = {
           enabled                      = true

--- a/variables.tf
+++ b/variables.tf
@@ -363,6 +363,15 @@ variable "typesense" {
 
   validation {
     condition = alltrue([
+      for app_name, config in var.typesense.apps : (
+        length(setsubtract(try(coalesce(config.log_check.notification_prompts, []), []), ["OPENED"])) == 0
+      )
+    ])
+    error_message = "log_check.notification_prompts only supports [\"OPENED\"]: the Cloud Monitoring API rejects other prompts on log-match alert policies (closure notifications are not available for them)."
+  }
+
+  validation {
+    condition = alltrue([
       for app_name, config in var.typesense.apps : alltrue([
         for value in concat(
           config.container_check != null ? [


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @andypanix._

## Summary

The 0.20.0 release exposed `notification_prompts` on `log_check`, and its example suggested `["OPENED", "CLOSED"]`. That value passes `terraform plan` but fails at apply: the Cloud Monitoring API only accepts `[OPENED]` on log-match alert policies.

```
Error 400: Field alertStrategy.notificationPrompts had an invalid value of "OPENED,CLOSED":
invalid notification prompts: log-based alert policies notification prompts must be [OPENED]
```

This PR:

- Adds a plan-time validation on the `typesense` variable rejecting `log_check.notification_prompts` values other than `["OPENED"]`.
- Fixes `examples/main.tf` to show `["OPENED"]` on `log_check` with a comment explaining the API constraint. `flood_check` (threshold-based) still accepts `["OPENED", "CLOSED"]`.
- Cuts the CHANGELOG for release 0.20.1.

## Testing

- `terraform validate` on `examples/` passes with the fixed example.
- Negative test: setting `["OPENED", "CLOSED"]` on the example `log_check` fails validate with the new plan-time error.
- `tflint` passes.
- The apply failure was reproduced on a real consumer (caleffi-gke): the two log-match policies were rejected by the API, while the two flood policies applied `["OPENED", "CLOSED"]` successfully.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Add plan-time validation for `log_check.notification_prompts` in `typesense` variable

- Reject values other than `["OPENED"]` since Cloud Monitoring API rejects them for log-match policies

- Fix `examples/main.tf` to use `["OPENED"]` on `log_check` with explanatory comment

- Cut CHANGELOG entry for release 0.20.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["variables.tf: typesense variable"] -- "adds validation block" --> B["log_check.notification_prompts"]
  B -- "must equal" --> C["[\"OPENED\"]"]
  D["examples/main.tf"] -- "updates log_check example" --> C
  E["CHANGELOG.md"] -- "documents fix" --> F["0.20.1 release"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add plan-time validation for log_check notification_prompts</code></dd></summary>
<hr>

variables.tf

<ul><li>Adds a new <code>validation</code> block to the <code>typesense</code> variable<br> <li> Ensures <code>log_check.notification_prompts</code> only contains <code>"OPENED"</code> for each <br>app config<br> <li> Uses <code>setsubtract</code> to detect disallowed values and raises a clear error <br>message</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/43/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Fix log_check example to use valid notification_prompts</code>&nbsp; &nbsp; </dd></summary>
<hr>

examples/main.tf

<ul><li>Updates <code>log_check.notification_prompts</code> example from <code>["OPENED", </code><br><code>"CLOSED"]</code> to <code>["OPENED"]</code><br> <li> Replaces outdated comment with explanation of Cloud Monitoring API <br>constraint</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/43/files#diff-96d2eb4482c8b32134388cfb862977ed0087f5a8acc4d73a8ad8d30985469f77">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document 0.20.1 release with fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds changelog entry for release 0.20.1<br> <li> Documents the fix for invalid <code>log_check.notification_prompts</code> values<br> <li> Includes comparison link and explanation of the API restriction</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-services-monitoring/pull/43/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

